### PR TITLE
Install the Instructor library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,4 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry.dependencies]
 python = "^3.12"
 pytest = "^8.3.4"
+instructor = "^1.7.0"


### PR DESCRIPTION
Fixes #7

Add the Instructor library to the project.

* Add `instructor` to the `[tool.poetry.dependencies]` section in `pyproject.toml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/machinehead/statemachine-instructor/pull/8?shareId=6c95bcd4-8b8b-4b0b-9d89-c447605d76fa).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `instructor` library to dependencies in `pyproject.toml`.
> 
>   - **Dependencies**:
>     - Add `instructor` library version `^1.7.0` to `[tool.poetry.dependencies]` in `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=machinehead%2Fstatemachine-instructor&utm_source=github&utm_medium=referral)<sup> for 6bd2aeadee483d44c4ca104489821f297b3d57be. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->